### PR TITLE
Update sqconfig.json

### DIFF
--- a/sqconfig.json
+++ b/sqconfig.json
@@ -27,7 +27,7 @@
 			"sceneCount":	300
 		},
 		"SQ7" : {
-			"channel":	48,
+			"chCount":	48,
 			"mixCount":	12,
 			"grpCount":	12,
 			"fxrCount":	8,
@@ -36,7 +36,7 @@
 			"dcaCount":	8,
 			"muteGroup":	8,
 			"SoftKey":	16,
-			"RotaryKey":	4,
+			"RotaryKey":	8,
 			"sceneCount":	300
 		}
 	}


### PR DESCRIPTION
input channels not showing on SQ7
SQ7 has 8 soft rotaries