### PR TITLE
Scene-manipulation actions don't work if the mixer isn't set to use MIDI channel 1

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1336,7 +1336,7 @@ module.exports = {
 				let opt = action.options;
 
 				sceneNumber = opt.scene - 1
-				cmd.buffers = [ Buffer.from([ self.mch, 0, (sceneNumber >> 7) & 0x0F, 0xC0, sceneNumber & 0x7F ]) ]
+				cmd.buffers = [ Buffer.from([ self.mch, 0, (sceneNumber >> 7) & 0x0F, 0xC0 | (self.mch & 0xF), sceneNumber & 0x7F ]) ]
 
 				self.sendBuffers(cmd.buffers);
 			}
@@ -1359,7 +1359,7 @@ module.exports = {
 				let opt = action.options;
 
 				sceneNumber = self.setScene(opt.scene)
-				cmd.buffers = [ Buffer.from([ self.mch, 0, (sceneNumber >> 7) & 0x0F, 0xC0, sceneNumber & 0x7F ]) ]
+				cmd.buffers = [ Buffer.from([ self.mch, 0, (sceneNumber >> 7) & 0x0F, 0xC0 | (self.mch & 0xF), sceneNumber & 0x7F ]) ]
 
 				self.sendBuffers(cmd.buffers);
 			}
@@ -1382,7 +1382,7 @@ module.exports = {
 				let opt = action.options;
 
 				sceneNumber = opt.scene - 1
-				cmd.buffers = [ Buffer.from([ self.mch, 0, (sceneNumber >> 7) & 0x0F, 0xC0, sceneNumber & 0x7F ]) ]
+				cmd.buffers = [ Buffer.from([ self.mch, 0, (sceneNumber >> 7) & 0x0F, 0xC0 | (self.mch & 0xF), sceneNumber & 0x7F ]) ]
 
 				self.sendBuffers(cmd.buffers);
 			}


### PR DESCRIPTION
I've been fooling around in module code (mostly refactoring it to make it understandable to me) and happened to run across this bug.  I have no idea if/when my fooling around will be complete enough to land (let alone whether it would be accepted), so I might as well save people from this bug before then.